### PR TITLE
feat(engine): BE1 — AST evaluator, workflow, schema parser, seed data…

### DIFF
--- a/backend/app/models/form.py
+++ b/backend/app/models/form.py
@@ -18,7 +18,7 @@ class Form(Base):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Версия схемы — критично для совместимости
-    schema_version: Mapped[str] = mapped_column(String(20), default="1.0")
+    schema_version: Mapped[str] = mapped_column(String(20), default="2.0.0")
 
     # Сама схема — JSONB, храним как есть, не парсим жёстко
     schema: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)

--- a/backend/app/schemas/form.py
+++ b/backend/app/schemas/form.py
@@ -12,7 +12,7 @@ class FormCreate(BaseModel):
     description: str | None = None
     # content — любой dict, мы не валидируем структуру внутри
     schema: dict[str, Any] = {}
-    schema_version: str = "1.0"
+    schema_version: str = "2.0.0"
 
     @field_validator("schema")
     @classmethod

--- a/backend/app/services/schema_handler.py
+++ b/backend/app/services/schema_handler.py
@@ -1,74 +1,90 @@
 """
-Schema Handler — schema-agnostic версионный интерпретатор.
-Backend не знает о конкретной структуре формы.
-Знает только минимальный контракт.
+Schema handler for published form definitions (BE2).
+
+Contract v2.0: root-level ``serviceCode`` and ``steps`` (AST-only; no ``content`` wrapper).
+The execution engine in ``engine/`` is separate and does not import this module.
 """
 
 from typing import Any
 
 
 class BaseSchemaHandler:
+    """Protocol-style base for versioned schema handlers."""
+
     def validate(self, schema: dict) -> bool:
+        """Return True if the document satisfies the minimal structural contract."""
         raise NotImplementedError
 
     def get_steps(self, schema: dict) -> list:
+        """Return the wizard steps array."""
         raise NotImplementedError
 
     def get_rules(self, schema: dict) -> list:
+        """Return optional rules list if present (legacy / builder analytics)."""
         raise NotImplementedError
 
 
-class SchemaV1Handler(BaseSchemaHandler):
+class SchemaV2Handler(BaseSchemaHandler):
     """
-    Обработчик для schema_version = "1.0"
-    Минимальный контракт: { "content": {...} }
-    Всё через .get() — никогда не падает на KeyError
+    Handler for schema version ``2.0.x`` — EPPB AST workflow shape.
+
+    Minimal contract:
+        - ``serviceCode`` (non-empty string)
+        - ``steps`` (list; may be empty only for drafts — still a list)
     """
 
     def validate(self, schema: dict) -> bool:
         if not isinstance(schema, dict):
             return False
-        # Единственное жёсткое требование — content должен быть объектом
-        content = schema.get("content")
-        if content is not None and not isinstance(content, dict):
+        code = schema.get("serviceCode")
+        if not isinstance(code, str) or not code.strip():
+            return False
+        steps = schema.get("steps")
+        if not isinstance(steps, list):
             return False
         return True
 
     def get_steps(self, schema: dict) -> list:
-        content = schema.get("content", {})
-        # Поддерживаем и "steps" и "pages" — фронт может поменять
-        return content.get("steps", content.get("pages", []))
+        return schema.get("steps", [])
 
     def get_rules(self, schema: dict) -> list:
-        content = schema.get("content", {})
-        return content.get("rules", [])
+        return schema.get("rules", [])
 
     def get_fields(self, schema: dict) -> list:
-        """Плоский список всех полей из всех шагов"""
-        fields = []
+        """Flat list of all field definitions across steps."""
+        fields: list = []
         for step in self.get_steps(schema):
             if isinstance(step, dict):
                 fields.extend(step.get("fields", []))
         return fields
 
 
-# Registry — добавляй новые версии сюда
 SCHEMA_HANDLERS: dict[str, BaseSchemaHandler] = {
-    "1.0": SchemaV1Handler(),
+    "2.0": SchemaV2Handler(),
+    "2.0.0": SchemaV2Handler(),
 }
 
 
 def get_handler(version: str) -> BaseSchemaHandler:
+    """Resolve handler for ``version``; defaults to v2.0."""
     handler = SCHEMA_HANDLERS.get(version)
     if not handler:
-        # Fallback на последнюю известную версию — не падаем
-        handler = SCHEMA_HANDLERS.get("1.0")
+        handler = SCHEMA_HANDLERS["2.0.0"]
     return handler
 
 
 def validate_schema(schema: dict[str, Any]) -> tuple[bool, str]:
-    """Возвращает (is_valid, error_message)"""
-    version = schema.get("version", "1.0")
+    """
+    Validate top-level JSON shape for API persistence.
+
+    Returns:
+        (True, \"\") on success, or (False, error_message).
+    """
+    if not isinstance(schema, dict):
+        return False, "Schema must be a JSON object"
+    version = schema.get("version", "2.0.0")
+    if not isinstance(version, str):
+        return False, "version must be a string"
     handler = get_handler(version)
     if not handler.validate(schema):
         return False, f"Invalid schema structure for version {version}"

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,16 @@
+"""EPPB workflow engine — pure AST-based schema parsing and execution (v2.0)."""
+
+from engine.schema_models import (
+    AdvanceResult,
+    SchemaValidationError,
+    ServiceSchema,
+)
+from engine.schema_parser import load_schema, validate_schema
+
+__all__ = [
+    "AdvanceResult",
+    "SchemaValidationError",
+    "ServiceSchema",
+    "load_schema",
+    "validate_schema",
+]

--- a/engine/ast_evaluator.py
+++ b/engine/ast_evaluator.py
@@ -1,0 +1,145 @@
+"""AST interpreter for conditions and calculated fields (no string eval)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _num(val: Any) -> float:
+    """
+    Coerce a value to float for numeric operations.
+
+    Raises:
+        TypeError: If the value cannot be converted to a number.
+        ValueError: If the value is not a valid number.
+    """
+    if isinstance(val, bool):
+        raise TypeError("boolean is not a number")
+    if isinstance(val, (int, float)):
+        return float(val)
+    if isinstance(val, str):
+        return float(val.strip())
+    raise TypeError(f"not numeric: {type(val).__name__}")
+
+
+def evaluate(node: dict[str, Any], context: dict[str, Any]) -> Any:
+    """
+    Evaluate an AST node against a field context (flat id -> value).
+
+    Supported node shapes:
+        - ``{"type": "ref", "field": "<id>"}``
+        - ``{"type": "value", "value": <any>}``
+        - ``{"type": "op", "op": "<name>", "args": [ ... ]}``
+
+    Supported operators:
+        Arithmetic: add, subtract, multiply, divide, round
+        Logic: and, or, not
+        Comparison: eq, neq, gt, gte, lt, lte, in, not_in
+        Constant truth: always (returns True)
+    """
+    if not isinstance(node, dict):
+        raise TypeError(f"AST node must be dict, got {type(node).__name__}")
+
+    ntype = node.get("type")
+    if ntype == "ref":
+        field = node.get("field")
+        if not isinstance(field, str):
+            raise TypeError("ref node requires string 'field'")
+        return context.get(field)
+
+    if ntype == "value":
+        return node.get("value")
+
+    if ntype == "op":
+        op = node.get("op")
+        if not isinstance(op, str):
+            raise TypeError("op node requires string 'op'")
+        raw_args = node.get("args", [])
+        if not isinstance(raw_args, list):
+            raise TypeError("op node 'args' must be a list")
+        args = [evaluate(child, context) for child in raw_args]
+
+        if op == "always":
+            return True
+
+        if op == "add":
+            if len(args) < 2:
+                raise ValueError("add requires 2 arguments")
+            return _num(args[0]) + _num(args[1])
+        if op == "subtract":
+            if len(args) < 2:
+                raise ValueError("subtract requires 2 arguments")
+            return _num(args[0]) - _num(args[1])
+        if op == "multiply":
+            if len(args) < 2:
+                raise ValueError("multiply requires 2 arguments")
+            return _num(args[0]) * _num(args[1])
+        if op == "divide":
+            b = _num(args[1])
+            if b == 0.0:
+                raise ZeroDivisionError("division by zero")
+            return _num(args[0]) / b
+        if op == "round":
+            if len(args) == 1:
+                return round(_num(args[0]))
+            if len(args) < 1:
+                raise ValueError("round requires at least 1 argument")
+            return round(_num(args[0]), int(args[1]))
+
+        if op == "not":
+            if len(args) < 1:
+                raise ValueError("not requires 1 argument")
+            return not bool(args[0])
+        if op == "and":
+            return all(bool(a) for a in args)
+        if op == "or":
+            return any(bool(a) for a in args)
+
+        if op == "eq":
+            if len(args) < 2:
+                raise ValueError("eq requires 2 arguments")
+            return args[0] == args[1]
+        if op == "neq":
+            if len(args) < 2:
+                raise ValueError("neq requires 2 arguments")
+            return args[0] != args[1]
+        if op == "gt":
+            if len(args) < 2:
+                raise ValueError("gt requires 2 arguments")
+            return _num(args[0]) > _num(args[1])
+        if op == "gte":
+            if len(args) < 2:
+                raise ValueError("gte requires 2 arguments")
+            return _num(args[0]) >= _num(args[1])
+        if op == "lt":
+            if len(args) < 2:
+                raise ValueError("lt requires 2 arguments")
+            return _num(args[0]) < _num(args[1])
+        if op == "lte":
+            if len(args) < 2:
+                raise ValueError("lte requires 2 arguments")
+            return _num(args[0]) <= _num(args[1])
+
+        if op == "in":
+            if len(args) < 2:
+                raise ValueError("in requires 2 arguments")
+            left, right = args[0], args[1]
+            if isinstance(right, (list, tuple, set)):
+                return left in right
+            if isinstance(right, str):
+                return left in right
+            raise TypeError("'in' right side must be collection or string")
+
+        if op == "not_in":
+            if len(args) < 2:
+                raise ValueError("not_in requires 2 arguments")
+            left, right = args[0], args[1]
+            if isinstance(right, (list, tuple, set)):
+                return left not in right
+            if isinstance(right, str):
+                return left not in right
+            raise TypeError("'not_in' right side must be collection or string")
+
+        raise ValueError(f"unsupported op: {op!r}")
+
+    raise ValueError(f"unknown AST node type: {ntype!r}")

--- a/engine/schema_models.py
+++ b/engine/schema_models.py
@@ -1,0 +1,143 @@
+"""Pydantic models for the EPPB service schema contract v2.0 (AST-only)."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+# --- AST nodes (discriminated union: ref | value | op) ---
+
+
+class RefNode(BaseModel):
+    """Reference to a field value in the evaluation context."""
+
+    type: Literal["ref"] = "ref"
+    field: str = Field(..., min_length=1)
+
+
+class ValueNode(BaseModel):
+    """Literal constant."""
+
+    type: Literal["value"] = "value"
+    value: Any
+
+
+class OpNode(BaseModel):
+    """Operator applied to child AST nodes."""
+
+    type: Literal["op"] = "op"
+    op: str = Field(..., min_length=1)
+    args: list["ASTNode"] = Field(default_factory=list)
+
+
+ASTNode = Annotated[RefNode | ValueNode | OpNode, Field(discriminator="type")]
+
+OpNode.model_rebuild()
+
+
+# --- Field definitions ---
+
+
+class FieldValidation(BaseModel):
+    """Declarative validation for user-editable fields."""
+
+    required: bool = False
+    pattern: str | None = None
+    min: float | None = None
+    max: float | None = None
+
+
+class AutofillConfig(BaseModel):
+    """Metadata for integration-driven autofill (execution is out of engine scope)."""
+
+    source: str = Field(
+        ...,
+        description="Integration key, e.g. egov_mock — resolved by BE2/FE at runtime.",
+    )
+
+
+class FormField(BaseModel):
+    """Single form field or calculated field on a step."""
+
+    id: str = Field(..., min_length=1)
+    type: Literal["string", "number", "select", "file", "calculated"] = "string"
+    label: str = ""
+    description: str | None = None
+    validation: FieldValidation | None = None
+    autofill: AutofillConfig | None = None
+    readonly: bool = False
+    disabled: bool = False
+    options: list[str] | None = None
+    deps: list[str] = Field(default_factory=list)
+    formula: dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def calculated_consistency(self) -> FormField:
+        if self.type == "calculated":
+            if not self.formula:
+                msg = f"Calculated field '{self.id}' must define 'formula' (AST object)"
+                raise ValueError(msg)
+        else:
+            if self.formula is not None or self.deps:
+                msg = f"Non-calculated field '{self.id}' must not set formula/deps"
+                raise ValueError(msg)
+        if self.type == "select":
+            if not self.options:
+                raise ValueError(f"Select field '{self.id}' must define non-empty options")
+        return self
+
+
+class Transition(BaseModel):
+    """Directed edge to the next step; condition is an AST root dict (validated at load)."""
+
+    to: str = Field(..., min_length=1)
+    condition: dict[str, Any]
+
+
+class Step(BaseModel):
+    """Wizard step: fields and outgoing transitions."""
+
+    id: str = Field(..., min_length=1)
+    title: str = ""
+    description: str | None = None
+    fields: list[FormField] = Field(default_factory=list)
+    transitions: list[Transition] = Field(default_factory=list)
+
+
+class ServiceConfig(BaseModel):
+    """Optional service-level flags."""
+
+    allow_drafts: bool = True
+    auto_save: bool = False
+    integration_required: list[str] = Field(default_factory=list)
+
+
+class ServiceSchema(BaseModel):
+    """Root document: serviceCode and steps at top level (v2.0 storage shape)."""
+
+    service_code: str = Field(..., alias="serviceCode")
+    version: str = "2.0.0"
+    title: str = ""
+    description: str | None = None
+    config: ServiceConfig | None = None
+    steps: list[Step] = Field(default_factory=list)
+
+    model_config = {"populate_by_name": True}
+
+
+class AdvanceResult(BaseModel):
+    """Outcome of advancing the application session by one step."""
+
+    next_step_id: str | None = None
+    errors: dict[str, str] = Field(default_factory=dict)
+    calculated: dict[str, Any] = Field(default_factory=dict)
+    is_final: bool = False
+
+
+class SchemaValidationError(Exception):
+    """Schema failed semantic validation."""
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__(f"Schema validation failed ({len(errors)} error(s)): {errors!r}")

--- a/engine/schema_parser.py
+++ b/engine/schema_parser.py
@@ -1,0 +1,140 @@
+"""Load and semantically validate v2.0 service schemas (AST-only)."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from typing import Any
+
+from pydantic import TypeAdapter, ValidationError
+
+from engine.schema_models import (
+    ASTNode,
+    FormField,
+    SchemaValidationError,
+    ServiceSchema,
+    Step,
+)
+
+_ast_adapter: TypeAdapter[ASTNode] = TypeAdapter(ASTNode)
+
+
+def _validate_ast_node(node: Any, path: str) -> list[str]:
+    if not isinstance(node, dict):
+        return [f"{path}: AST node must be an object, got {type(node).__name__}"]
+    try:
+        _ast_adapter.validate_python(node)
+    except ValidationError as e:
+        return [f"{path}: invalid AST — {e!s}"]
+    return []
+
+
+def _step_field_ids(step: Step) -> dict[str, FormField]:
+    return {f.id: f for f in step.fields}
+
+
+def _detect_calc_cycles(fields: list[FormField]) -> list[str]:
+    """Return error messages if calculated fields have cyclic deps (Kahn)."""
+    calc_by_id = {f.id: f for f in fields if f.type == "calculated"}
+    if not calc_by_id:
+        return []
+
+    in_degree: dict[str, int] = {fid: 0 for fid in calc_by_id}
+    graph: dict[str, list[str]] = defaultdict(list)
+
+    for fid, f in calc_by_id.items():
+        for dep in f.deps:
+            if dep in calc_by_id:
+                graph[dep].append(fid)
+                in_degree[fid] += 1
+
+    queue: deque[str] = deque(n for n, d in in_degree.items() if d == 0)
+    seen = 0
+    while queue:
+        n = queue.popleft()
+        seen += 1
+        for m in graph[n]:
+            in_degree[m] -= 1
+            if in_degree[m] == 0:
+                queue.append(m)
+
+    if seen != len(calc_by_id):
+        return ["Calculated fields contain a cyclic dependency chain"]
+    return []
+
+
+def validate_schema(schema: ServiceSchema) -> list[str]:
+    """
+    Run semantic checks on a parsed schema.
+
+    Returns an empty list if valid; otherwise all accumulated error messages.
+    """
+    errors: list[str] = []
+    step_ids = {s.id for s in schema.steps}
+
+    for step in schema.steps:
+        sid = step.id
+        fields = step.fields
+        by_id = _step_field_ids(step)
+        ids_seen: set[str] = set()
+        for f in fields:
+            if f.id in ids_seen:
+                errors.append(f"Step '{sid}': duplicate field id '{f.id}'")
+            ids_seen.add(f.id)
+
+        for f in fields:
+            if f.type == "calculated":
+                if f.formula is None:
+                    errors.append(f"Step '{sid}': calculated '{f.id}' missing formula")
+                    continue
+                errors.extend(_validate_ast_node(f.formula, f"Step '{sid}' field '{f.id}' formula"))
+                for dep in f.deps:
+                    if dep not in by_id:
+                        errors.append(
+                            f"Step '{sid}': calculated '{f.id}' dep '{dep}' "
+                            f"is not a field on this step"
+                        )
+                    elif dep == f.id:
+                        errors.append(
+                            f"Step '{sid}': calculated '{f.id}' must not depend on itself"
+                        )
+                # deps must only reference non-calculated OR calculated that appear as separate fields
+                # (already ensured by by_id)
+            else:
+                if f.formula is not None:
+                    errors.append(f"Step '{sid}': field '{f.id}' must not have formula")
+                if f.deps:
+                    errors.append(f"Step '{sid}': field '{f.id}' must not have deps")
+
+        errors.extend(
+            f"Step '{sid}': {msg}"
+            for msg in _detect_calc_cycles(fields)
+        )
+
+        for i, t in enumerate(step.transitions):
+            if t.to not in step_ids:
+                errors.append(
+                    f"Step '{sid}' transition[{i}]: target '{t.to}' is not a defined step id"
+                )
+            errors.extend(
+                _validate_ast_node(
+                    t.condition,
+                    f"Step '{sid}' transition[{i}] condition",
+                )
+            )
+
+    return errors
+
+
+def load_schema(raw: dict[str, Any]) -> ServiceSchema:
+    """
+    Parse a raw JSON object into ``ServiceSchema`` and validate semantics.
+
+    Raises:
+        SchemaValidationError: If parsing fails or semantic validation fails.
+        ValidationError: If the document does not match the Pydantic model (Pydantic).
+    """
+    schema = ServiceSchema.model_validate(raw)
+    errors = validate_schema(schema)
+    if errors:
+        raise SchemaValidationError(errors)
+    return schema

--- a/engine/workflow.py
+++ b/engine/workflow.py
@@ -1,0 +1,230 @@
+"""Workflow: calculated fields, validation, transitions, application session."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict, deque
+from typing import Any
+
+from engine.ast_evaluator import _num, evaluate
+from engine.schema_models import AdvanceResult, ServiceSchema, Step
+
+
+class CyclicDependencyError(Exception):
+    """Raised when calculated fields depend on each other in a cycle."""
+
+    def __init__(self, message: str = "Cyclic dependency among calculated fields") -> None:
+        super().__init__(message)
+
+
+def _step_by_id(schema: ServiceSchema) -> dict[str, Step]:
+    return {s.id: s for s in schema.steps}
+
+
+def _topo_sort_calculated(fields: list[Any]) -> list[dict[str, Any]]:
+    """
+    Topologically sort calculated ``fields`` (dicts with ``id``, ``deps``, ``type``).
+
+    Raises:
+        CyclicDependencyError: If a cycle exists among calculated fields.
+    """
+    calc = [f for f in fields if f.get("type") == "calculated"]
+    if not calc:
+        return []
+
+    calc_ids = {f["id"] for f in calc}
+    in_degree: dict[str, int] = {fid: 0 for fid in calc_ids}
+    graph: dict[str, list[str]] = defaultdict(list)
+
+    for f in calc:
+        fid = f["id"]
+        for dep in f.get("deps") or []:
+            if dep in calc_ids:
+                graph[dep].append(fid)
+                in_degree[fid] += 1
+
+    queue: deque[str] = deque(n for n, d in in_degree.items() if d == 0)
+    ordered: list[dict[str, Any]] = []
+    while queue:
+        n = queue.popleft()
+        fobj = next(x for x in calc if x["id"] == n)
+        ordered.append(fobj)
+        for m in graph[n]:
+            in_degree[m] -= 1
+            if in_degree[m] == 0:
+                queue.append(m)
+
+    if len(ordered) != len(calc):
+        raise CyclicDependencyError()
+    return ordered
+
+
+def compute_calculated_fields(step: dict[str, Any], field_values: dict[str, Any]) -> dict[str, Any]:
+    """
+    Evaluate calculated fields on a step in dependency order.
+
+    Non-calculated values are taken from ``field_values``; results are merged in order.
+    """
+    fields = step.get("fields") or []
+    ordered = _topo_sort_calculated(fields)
+    ctx: dict[str, Any] = dict(field_values)
+    out: dict[str, Any] = {}
+    for cf in ordered:
+        fid = cf["id"]
+        formula = cf.get("formula")
+        if not formula:
+            continue
+        val = evaluate(formula, ctx)
+        ctx[fid] = val
+        out[fid] = val
+    return out
+
+
+def validate_step(step: dict[str, Any], field_values: dict[str, Any]) -> dict[str, str]:
+    """
+    Validate user-editable fields on a step; skip ``calculated`` fields.
+
+    Returns a map ``field_id -> error message``.
+    """
+    errors: dict[str, str] = {}
+    fields: list[dict[str, Any]] = step.get("fields") or []
+
+    for fd in fields:
+        if fd.get("type") == "calculated":
+            continue
+
+        fid = fd["id"]
+        raw = field_values.get(fid)
+        v = fd.get("validation") or {}
+        required = bool(v.get("required"))
+        if required and (raw is None or raw == ""):
+            errors[fid] = "This field is required"
+            continue
+
+        if raw is None or raw == "":
+            continue
+
+        ftype = fd.get("type", "string")
+        pattern = v.get("pattern")
+        if pattern and isinstance(raw, str):
+            if re.fullmatch(pattern, raw) is None:
+                errors[fid] = "Value does not match required pattern"
+                continue
+
+        if ftype == "number":
+            try:
+                num = _num(raw)
+            except (TypeError, ValueError):
+                errors[fid] = "Must be a valid number"
+                continue
+            if v.get("min") is not None and num < _num(v["min"]):
+                errors[fid] = f"Must be >= {v['min']}"
+                continue
+            if v.get("max") is not None and num > _num(v["max"]):
+                errors[fid] = f"Must be <= {v['max']}"
+                continue
+
+        opts = fd.get("options")
+        if ftype == "select" and opts is not None and raw not in opts:
+            errors[fid] = "Invalid option"
+
+    return errors
+
+
+def resolve_next_step(step: dict[str, Any], field_values: dict[str, Any]) -> str | None:
+    """
+    Return ``to`` of the first transition whose condition evaluates truthy.
+
+    Order is preserved; ``always`` should be used as a catch-all last transition.
+    """
+    for t in step.get("transitions") or []:
+        cond = t.get("condition")
+        if cond is None:
+            continue
+        if bool(evaluate(cond, field_values)):
+            return t.get("to")
+    return None
+
+
+class ApplicationSession:
+    """
+    Stateful wizard session: validation, calculated fields, transition resolution,
+    history with rollback.
+    """
+
+    def __init__(self, schema: ServiceSchema) -> None:
+        self._schema = schema
+        self._steps = _step_by_id(schema)
+        self._step_ids = set(self._steps.keys())
+        self._accumulated: dict[str, Any] = {}
+        self._history: list[str] = []
+        self._snapshots: list[dict[str, Any]] = []
+
+    def is_final_step(self, step_id: str) -> bool:
+        """
+        True if the step has no outgoing transitions, or every ``to`` target is unknown.
+
+        Unknown targets are treated as terminal per product decision (risk #5).
+        """
+        step = self._steps.get(step_id)
+        if not step:
+            return True
+        transitions = step.transitions
+        if not transitions:
+            return True
+        return all(t.to not in self._step_ids for t in transitions)
+
+    def get_accumulated_values(self) -> dict[str, Any]:
+        """Return a shallow copy of all field values collected so far."""
+        return dict(self._accumulated)
+
+    def back(self) -> str | None:
+        """
+        Undo the last successful ``advance`` and restore accumulated values.
+
+        Returns the step id to return to, or ``None`` if history is empty.
+        """
+        if not self._history:
+            return None
+        self._history.pop()
+        if self._snapshots:
+            self._snapshots.pop()
+        if self._snapshots:
+            self._accumulated = dict(self._snapshots[-1])
+        else:
+            self._accumulated = {}
+        return self._history[-1] if self._history else None
+
+    def advance(self, step_id: str, field_values: dict[str, Any]) -> AdvanceResult:
+        """
+        Validate user input for ``step_id``, merge calculated fields, resolve next step,
+        and record history on success.
+        """
+        step_model = self._steps.get(step_id)
+        if not step_model:
+            return AdvanceResult(
+                errors={"__step__": f"Unknown step: {step_id}"},
+            )
+
+        step = step_model.model_dump(mode="json", by_alias=True)
+        merged_for_validate = {**self._accumulated, **field_values}
+        errors = validate_step(step, merged_for_validate)
+        if errors:
+            return AdvanceResult(errors=errors)
+
+        merged_for_calc = {**self._accumulated, **field_values}
+        calculated = compute_calculated_fields(step, merged_for_calc)
+        full_context = {**merged_for_calc, **calculated}
+
+        next_step_id = resolve_next_step(step, full_context)
+        is_final = next_step_id is None and self.is_final_step(step_id)
+
+        self._accumulated = dict(full_context)
+        self._history.append(step_id)
+        self._snapshots.append(dict(self._accumulated))
+
+        return AdvanceResult(
+            next_step_id=next_step_id,
+            calculated=calculated,
+            is_final=is_final,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eppb-platform"
+version = "0.1.0"
+description = "EPPB monorepo — engine package for AST workflow (v2.0)"
+requires-python = ">=3.11"
+dependencies = [
+    "pydantic>=2.7,<3",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["engine*"]

--- a/seed_data/leasing_stage1.json
+++ b/seed_data/leasing_stage1.json
@@ -1,0 +1,180 @@
+{
+  "serviceCode": "leasing-aviation-wagons-stage1",
+  "version": "2.0.0",
+  "title": "Приобретение авиатранспорта и вагонов в лизинг — I этап",
+  "description": "Первая ступень заявки на лизинг авиатранспорта и вагонов",
+  "config": {
+    "allow_drafts": true,
+    "auto_save": true,
+    "integration_required": ["egov_mock"]
+  },
+  "steps": [
+    {
+      "id": "step_1_company",
+      "title": "Сведения о компании",
+      "description": "Идентификация и форма собственности",
+      "fields": [
+        {
+          "id": "bin",
+          "type": "string",
+          "label": "БИН компании",
+          "validation": {
+            "required": true,
+            "pattern": "^\\d{12}$"
+          },
+          "autofill": { "source": "egov_mock" }
+        },
+        {
+          "id": "company_name",
+          "type": "string",
+          "label": "Наименование",
+          "readonly": true,
+          "disabled": true
+        },
+        {
+          "id": "ownership_type",
+          "type": "select",
+          "label": "Форма собственности",
+          "validation": { "required": true },
+          "options": ["ТОО", "АО", "ИП"]
+        }
+      ],
+      "transitions": [
+        {
+          "to": "step_2_leasing",
+          "condition": { "type": "op", "op": "always", "args": [] }
+        }
+      ]
+    },
+    {
+      "id": "step_2_leasing",
+      "title": "Параметры лизинга",
+      "fields": [
+        {
+          "id": "wagon_count",
+          "type": "number",
+          "label": "Количество вагонов",
+          "validation": { "required": true, "min": 1, "max": 10000 }
+        },
+        {
+          "id": "wagon_price",
+          "type": "number",
+          "label": "Цена за единицу, ₸",
+          "validation": { "required": true, "min": 0 }
+        },
+        {
+          "id": "total_cost",
+          "type": "calculated",
+          "label": "Общая стоимость, ₸",
+          "readonly": true,
+          "deps": ["wagon_count", "wagon_price"],
+          "formula": {
+            "type": "op",
+            "op": "multiply",
+            "args": [
+              { "type": "ref", "field": "wagon_count" },
+              { "type": "ref", "field": "wagon_price" }
+            ]
+          }
+        },
+        {
+          "id": "leasing_term",
+          "type": "select",
+          "label": "Срок лизинга",
+          "validation": { "required": true },
+          "options": ["12 мес.", "24 мес.", "36 мес.", "60 мес."]
+        }
+      ],
+      "transitions": [
+        {
+          "to": "step_3_documents_gate",
+          "condition": { "type": "op", "op": "always", "args": [] }
+        }
+      ]
+    },
+    {
+      "id": "step_3_documents_gate",
+      "title": "Документы — маршрутизация",
+      "description": "Выбор набора документов по форме собственности",
+      "fields": [],
+      "transitions": [
+        {
+          "to": "step_documents_lite",
+          "condition": {
+            "type": "op",
+            "op": "eq",
+            "args": [
+              { "type": "ref", "field": "ownership_type" },
+              { "type": "value", "value": "ИП" }
+            ]
+          }
+        },
+        {
+          "to": "step_documents_full",
+          "condition": { "type": "op", "op": "always", "args": [] }
+        }
+      ]
+    },
+    {
+      "id": "step_documents_lite",
+      "title": "Загрузка документов (упрощённый комплект)",
+      "fields": [
+        {
+          "id": "id_document",
+          "type": "file",
+          "label": "Удостоверение личности",
+          "validation": { "required": true }
+        },
+        {
+          "id": "lease_application_scan",
+          "type": "file",
+          "label": "Скан заявления",
+          "validation": { "required": true }
+        }
+      ],
+      "transitions": [
+        {
+          "to": "step_complete",
+          "condition": { "type": "op", "op": "always", "args": [] }
+        }
+      ]
+    },
+    {
+      "id": "step_documents_full",
+      "title": "Загрузка документов (полный комплект)",
+      "fields": [
+        {
+          "id": "financial_report",
+          "type": "file",
+          "label": "Финансовая отчётность",
+          "validation": { "required": true }
+        },
+        {
+          "id": "charter_scan",
+          "type": "file",
+          "label": "Устав / учредительные документы",
+          "validation": { "required": true }
+        },
+        {
+          "id": "lease_application_scan_full",
+          "type": "file",
+          "label": "Скан заявления",
+          "validation": { "required": true }
+        }
+      ],
+      "transitions": [
+        {
+          "to": "step_complete",
+          "condition": { "type": "op", "op": "always", "args": [] }
+        }
+      ]
+    },
+    {
+      "id": "step_complete",
+      "title": "Заявка сформирована",
+      "description": "Терминальный шаг этапа I",
+      "fields": [],
+      "transitions": []
+    }
+  ]
+}

--- a/seed_data/leasing_stage2.json
+++ b/seed_data/leasing_stage2.json
@@ -1,0 +1,167 @@
+{
+  "serviceCode": "leasing-aviation-wagons-stage2",
+  "version": "2.0.0",
+  "title": "Приобретение авиатранспорта и вагонов в лизинг — II этап",
+  "description": "Вторая ступень заявки (продолжение после этапа I)",
+  "config": {
+    "allow_drafts": true,
+    "integration_required": ["egov_mock"]
+  },
+  "steps": [
+    {
+      "id": "step_1_link",
+      "title": "Связь с этапом I",
+      "fields": [
+        {
+          "id": "stage1_application_id",
+          "type": "string",
+          "label": "Номер заявки этапа I",
+          "validation": { "required": true, "pattern": "^[A-Z0-9\\-]{6,64}$" }
+        },
+        {
+          "id": "bin",
+          "type": "string",
+          "label": "БИН компании",
+          "validation": { "required": true, "pattern": "^\\d{12}$" },
+          "autofill": { "source": "egov_mock" }
+        },
+        {
+          "id": "company_name",
+          "type": "string",
+          "label": "Наименование",
+          "readonly": true,
+          "disabled": true
+        },
+        {
+          "id": "ownership_type",
+          "type": "select",
+          "label": "Форма собственности",
+          "validation": { "required": true },
+          "options": ["ТОО", "АО", "ИП"]
+        }
+      ],
+      "transitions": [
+        {
+          "to": "step_2_terms",
+          "condition": { "type": "op", "op": "always", "args": [] }
+        }
+      ]
+    },
+    {
+      "id": "step_2_terms",
+      "title": "Условия этапа II",
+      "fields": [
+        {
+          "id": "asset_units",
+          "type": "number",
+          "label": "Количество единиц актива",
+          "validation": { "required": true, "min": 1 }
+        },
+        {
+          "id": "unit_price",
+          "type": "number",
+          "label": "Стоимость единицы, ₸",
+          "validation": { "required": true, "min": 0 }
+        },
+        {
+          "id": "stage2_total",
+          "type": "calculated",
+          "label": "Итого по этапу II, ₸",
+          "readonly": true,
+          "deps": ["asset_units", "unit_price"],
+          "formula": {
+            "type": "op",
+            "op": "multiply",
+            "args": [
+              { "type": "ref", "field": "asset_units" },
+              { "type": "ref", "field": "unit_price" }
+            ]
+          }
+        },
+        {
+          "id": "review_term",
+          "type": "select",
+          "label": "Срок рассмотрения",
+          "validation": { "required": true },
+          "options": ["15 р.д.", "30 р.д."]
+        }
+      ],
+      "transitions": [
+        {
+          "to": "step_3_docs_branch",
+          "condition": { "type": "op", "op": "always", "args": [] }
+        }
+      ]
+    },
+    {
+      "id": "step_3_docs_branch",
+      "title": "Документы — маршрутизация",
+      "fields": [],
+      "transitions": [
+        {
+          "to": "step_docs_lite_2",
+          "condition": {
+            "type": "op",
+            "op": "eq",
+            "args": [
+              { "type": "ref", "field": "ownership_type" },
+              { "type": "value", "value": "ИП" }
+            ]
+          }
+        },
+        {
+          "to": "step_docs_full_2",
+          "condition": { "type": "op", "op": "always", "args": [] }
+        }
+      ]
+    },
+    {
+      "id": "step_docs_lite_2",
+      "title": "Документы (ИП)",
+      "fields": [
+        {
+          "id": "statement_ip",
+          "type": "file",
+          "label": "Заявление ИП",
+          "validation": { "required": true }
+        }
+      ],
+      "transitions": [
+        {
+          "to": "step_complete_2",
+          "condition": { "type": "op", "op": "always", "args": [] }
+        }
+      ]
+    },
+    {
+      "id": "step_docs_full_2",
+      "title": "Документы (юрлицо)",
+      "fields": [
+        {
+          "id": "financials_stage2",
+          "type": "file",
+          "label": "Финансовая отчётность",
+          "validation": { "required": true }
+        },
+        {
+          "id": "board_minutes",
+          "type": "file",
+          "label": "Протокол органа управления",
+          "validation": { "required": true }
+        }
+      ],
+      "transitions": [
+        {
+          "to": "step_complete_2",
+          "condition": { "type": "op", "op": "always", "args": [] }
+        }
+      ]
+    },
+    {
+      "id": "step_complete_2",
+      "title": "Этап II завершён",
+      "fields": [],
+      "transitions": []
+    }
+  ]
+}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,480 @@
+"""Unit tests for the AST workflow engine (v2.0)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from engine.ast_evaluator import _num, evaluate
+from engine.schema_models import FormField, SchemaValidationError, ServiceSchema, Step
+from engine.schema_parser import load_schema, validate_schema
+from engine.workflow import (
+    ApplicationSession,
+    CyclicDependencyError,
+    compute_calculated_fields,
+    resolve_next_step,
+    validate_step,
+    _topo_sort_calculated,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+STAGE1 = ROOT / "seed_data" / "leasing_stage1.json"
+
+
+# --- ast_evaluator ---
+
+
+def test_evaluate_ref_and_value():
+    ctx = {"a": 3}
+    assert evaluate({"type": "ref", "field": "a"}, ctx) == 3
+    assert evaluate({"type": "value", "value": "x"}, ctx) == "x"
+
+
+def test_evaluate_arithmetic_and_round():
+    ctx = {}
+    n2 = {"type": "value", "value": 2}
+    n5 = {"type": "value", "value": 5}
+    assert (
+        evaluate({"type": "op", "op": "add", "args": [n2, n5]}, ctx) == 7.0
+    )
+    assert (
+        evaluate({"type": "op", "op": "subtract", "args": [n5, n2]}, ctx) == 3.0
+    )
+    assert (
+        evaluate({"type": "op", "op": "multiply", "args": [n2, n5]}, ctx) == 10.0
+    )
+    assert (
+        evaluate({"type": "op", "op": "divide", "args": [n5, n2]}, ctx) == 2.5
+    )
+    assert evaluate({"type": "op", "op": "round", "args": [n2]}, ctx) == 2
+
+
+def test_evaluate_divide_by_zero():
+    ctx = {}
+    with pytest.raises(ZeroDivisionError):
+        evaluate(
+            {
+                "type": "op",
+                "op": "divide",
+                "args": [
+                    {"type": "value", "value": 1},
+                    {"type": "value", "value": 0},
+                ],
+            },
+            ctx,
+        )
+
+
+def test_evaluate_logic_and_comparison():
+    t = {"type": "value", "value": True}
+    f = {"type": "value", "value": False}
+    assert evaluate({"type": "op", "op": "not", "args": [f]}, {}) is True
+    assert evaluate({"type": "op", "op": "and", "args": [t, t]}, {}) is True
+    assert evaluate({"type": "op", "op": "or", "args": [f, t]}, {}) is True
+    a = {"type": "value", "value": 1}
+    b = {"type": "value", "value": 2}
+    assert evaluate({"type": "op", "op": "eq", "args": [a, a]}, {}) is True
+    assert evaluate({"type": "op", "op": "neq", "args": [a, b]}, {}) is True
+    assert evaluate({"type": "op", "op": "lt", "args": [a, b]}, {}) is True
+    assert evaluate({"type": "op", "op": "lte", "args": [b, b]}, {}) is True
+    assert evaluate({"type": "op", "op": "gt", "args": [b, a]}, {}) is True
+    assert evaluate({"type": "op", "op": "gte", "args": [b, a]}, {}) is True
+
+
+def test_evaluate_in_ops():
+    ctx = {"role": "admin"}
+    assert (
+        evaluate(
+            {
+                "type": "op",
+                "op": "in",
+                "args": [
+                    {"type": "ref", "field": "role"},
+                    {"type": "value", "value": ["user", "admin"]},
+                ],
+            },
+            ctx,
+        )
+        is True
+    )
+    assert (
+        evaluate(
+            {
+                "type": "op",
+                "op": "not_in",
+                "args": [
+                    {"type": "value", "value": "x"},
+                    {"type": "value", "value": ["a", "b"]},
+                ],
+            },
+            {},
+        )
+        is True
+    )
+
+
+def test_evaluate_always():
+    assert (
+        evaluate({"type": "op", "op": "always", "args": []}, {}) is True
+    )
+
+
+def test_evaluate_nested_ast():
+    ctx = {"x": 10}
+    tree = {
+        "type": "op",
+        "op": "multiply",
+        "args": [
+            {"type": "op", "op": "add", "args": [{"type": "ref", "field": "x"}, {"type": "value", "value": 5}]},
+            {"type": "value", "value": 2},
+        ],
+    }
+    assert evaluate(tree, ctx) == 30.0
+
+
+def test_num_coercion():
+    assert _num(3) == 3.0
+    assert _num("4.5") == 4.5
+    with pytest.raises(TypeError):
+        _num(True)
+
+
+# --- schema validation ---
+
+
+def _minimal_valid_schema() -> ServiceSchema:
+    return ServiceSchema.model_validate(
+        {
+            "serviceCode": "test",
+            "version": "2.0.0",
+            "steps": [
+                {
+                    "id": "a",
+                    "fields": [
+                        {"id": "f1", "type": "string", "label": "F1"},
+                        {
+                            "id": "c1",
+                            "type": "calculated",
+                            "label": "C1",
+                            "deps": ["f1"],
+                            "formula": {"type": "ref", "field": "f1"},
+                        },
+                    ],
+                    "transitions": [{"to": "b", "condition": {"type": "op", "op": "always", "args": []}}],
+                },
+                {"id": "b", "fields": [], "transitions": []},
+            ],
+        }
+    )
+
+
+def test_validate_schema_passes():
+    s = _minimal_valid_schema()
+    assert validate_schema(s) == []
+
+
+def test_validate_schema_duplicate_field():
+    step = Step(
+        id="a",
+        fields=[
+            FormField(id="x", type="string", label=""),
+            FormField(id="x", type="string", label=""),
+        ],
+        transitions=[],
+    )
+    s = ServiceSchema(serviceCode="t", steps=[step])
+    errs = validate_schema(s)
+    assert any("duplicate field" in e for e in errs)
+
+
+def test_validate_schema_bad_transition_target():
+    s = ServiceSchema.model_validate(
+        {
+            "serviceCode": "t",
+            "steps": [
+                {
+                    "id": "a",
+                    "fields": [],
+                    "transitions": [
+                        {"to": "missing", "condition": {"type": "op", "op": "always", "args": []}}
+                    ],
+                }
+            ],
+        }
+    )
+    errs = validate_schema(s)
+    assert any("not a defined step" in e for e in errs)
+
+
+def test_validate_schema_calc_cycle():
+    s = ServiceSchema.model_validate(
+        {
+            "serviceCode": "t",
+            "steps": [
+                {
+                    "id": "a",
+                    "fields": [
+                        {
+                            "id": "c1",
+                            "type": "calculated",
+                            "deps": ["c2"],
+                            "formula": {"type": "value", "value": 1},
+                        },
+                        {
+                            "id": "c2",
+                            "type": "calculated",
+                            "deps": ["c1"],
+                            "formula": {"type": "value", "value": 2},
+                        },
+                    ],
+                    "transitions": [],
+                }
+            ],
+        }
+    )
+    errs = validate_schema(s)
+    assert any("cyclic" in e.lower() for e in errs)
+
+
+def test_validate_schema_invalid_ast_in_formula():
+    s = ServiceSchema.model_validate(
+        {
+            "serviceCode": "t",
+            "steps": [
+                {
+                    "id": "a",
+                    "fields": [
+                        {
+                            "id": "c1",
+                            "type": "calculated",
+                            "deps": [],
+                            "formula": {"type": "ref"},
+                        },
+                    ],
+                    "transitions": [],
+                }
+            ],
+        }
+    )
+    errs = validate_schema(s)
+    assert errs
+
+
+# --- validate_step ---
+
+
+def test_validate_step_required_and_pattern():
+    step = {
+        "fields": [
+            {
+                "id": "code",
+                "type": "string",
+                "validation": {"required": True, "pattern": "^[A-Z]{2}$"},
+            }
+        ]
+    }
+    assert "code" in validate_step(step, {})
+    assert "code" in validate_step(step, {"code": "bad"})
+    assert validate_step(step, {"code": "AB"}) == {}
+
+
+def test_validate_step_min_max_number():
+    step = {
+        "fields": [
+            {
+                "id": "n",
+                "type": "number",
+                "validation": {"required": True, "min": 2, "max": 5},
+            }
+        ]
+    }
+    assert "n" in validate_step(step, {"n": 1})
+    assert "n" in validate_step(step, {"n": 10})
+    assert validate_step(step, {"n": 3}) == {}
+
+
+def test_validate_step_skips_calculated():
+    step = {
+        "fields": [
+            {
+                "id": "c",
+                "type": "calculated",
+                "deps": [],
+                "formula": {"type": "value", "value": 1},
+            }
+        ]
+    }
+    assert validate_step(step, {}) == {}
+
+
+# --- resolve_next_step ---
+
+
+def test_resolve_first_match_and_always_fallback():
+    step = {
+        "transitions": [
+            {
+                "to": "high",
+                "condition": {
+                    "type": "op",
+                    "op": "gt",
+                    "args": [{"type": "ref", "field": "cost"}, {"type": "value", "value": 10}],
+                },
+            },
+            {
+                "to": "low",
+                "condition": {"type": "op", "op": "always", "args": []},
+            },
+        ]
+    }
+    assert resolve_next_step(step, {"cost": 20}) == "high"
+    assert resolve_next_step(step, {"cost": 5}) == "low"
+
+
+def test_resolve_no_match():
+    step = {
+        "transitions": [
+            {
+                "to": "x",
+                "condition": {
+                    "type": "op",
+                    "op": "gt",
+                    "args": [{"type": "ref", "field": "cost"}, {"type": "value", "value": 100}],
+                },
+            }
+        ]
+    }
+    assert resolve_next_step(step, {"cost": 1}) is None
+
+
+# --- topo / computed ---
+
+
+def test_topo_chained_calculated():
+    step = {
+        "fields": [
+            {
+                "id": "base",
+                "type": "number",
+                "validation": {"required": True},
+            },
+            {
+                "id": "c1",
+                "type": "calculated",
+                "deps": ["base"],
+                "formula": {
+                    "type": "op",
+                    "op": "multiply",
+                    "args": [{"type": "ref", "field": "base"}, {"type": "value", "value": 2}],
+                },
+            },
+            {
+                "id": "c2",
+                "type": "calculated",
+                "deps": ["c1"],
+                "formula": {
+                    "type": "op",
+                    "op": "add",
+                    "args": [{"type": "ref", "field": "c1"}, {"type": "value", "value": 1}],
+                },
+            },
+        ]
+    }
+    out = compute_calculated_fields(step, {"base": 3})
+    assert out["c1"] == 6.0
+    assert out["c2"] == 7.0
+
+
+def test_topo_sort_cycle_raises():
+    fields = [
+        {"id": "a", "type": "calculated", "deps": ["b"], "formula": {"type": "value", "value": 1}},
+        {"id": "b", "type": "calculated", "deps": ["a"], "formula": {"type": "value", "value": 2}},
+    ]
+    with pytest.raises(CyclicDependencyError):
+        _topo_sort_calculated(fields)
+
+
+# --- ApplicationSession ---
+
+
+def test_application_session_advance_and_back():
+    schema = _minimal_valid_schema()
+    session = ApplicationSession(schema)
+    r1 = session.advance("a", {"f1": "ok"})
+    assert r1.errors == {}
+    assert r1.calculated == {"c1": "ok"}
+    assert r1.next_step_id == "b"
+    assert not r1.is_final
+
+    r2 = session.advance("b", {})
+    assert r2.next_step_id is None
+    assert r2.is_final
+
+    prev = session.back()
+    assert prev == "a"
+    assert session.get_accumulated_values() == {"f1": "ok", "c1": "ok"}
+
+
+def test_application_session_validation_errors():
+    schema = ServiceSchema.model_validate(
+        {
+            "serviceCode": "t",
+            "steps": [
+                {
+                    "id": "a",
+                    "fields": [
+                        {"id": "req", "type": "string", "validation": {"required": True}},
+                    ],
+                    "transitions": [],
+                }
+            ],
+        }
+    )
+    session = ApplicationSession(schema)
+    r = session.advance("a", {})
+    assert r.errors
+    assert session.get_accumulated_values() == {}
+
+
+def test_is_final_all_transitions_invalid_targets():
+    schema = ServiceSchema.model_validate(
+        {
+            "serviceCode": "t",
+            "steps": [
+                {
+                    "id": "a",
+                    "fields": [],
+                    "transitions": [
+                        {"to": "ghost", "condition": {"type": "op", "op": "always", "args": []}}
+                    ],
+                }
+            ],
+        }
+    )
+    session = ApplicationSession(schema)
+    assert session.is_final_step("a") is True
+
+
+def test_load_schema_leasing_stage1():
+    raw = json.loads(STAGE1.read_text(encoding="utf-8"))
+    schema = load_schema(raw)
+    assert schema.service_code == "leasing-aviation-wagons-stage1"
+    assert len(schema.steps) >= 5
+
+
+def test_load_schema_raises_on_semantic_errors():
+    bad = {
+        "serviceCode": "x",
+        "steps": [
+            {
+                "id": "a",
+                "fields": [],
+                "transitions": [
+                    {"to": "nonexistent", "condition": {"type": "op", "op": "always", "args": []}}
+                ],
+            }
+        ],
+    }
+    with pytest.raises(SchemaValidationError):
+        load_schema(bad)


### PR DESCRIPTION
## BE1 — Engine core

Closes #2, #5, #7

### Что сделано
- engine/schema_models.py — Pydantic v2 модели контракта v2.0 (AST)
- engine/schema_parser.py — load_schema, validate_schema
- engine/ast_evaluator.py — рекурсивный AST интерпретатор, без eval()
- engine/workflow.py — топосорт, ApplicationSession, validate_step, resolve_next_step
- seed_data/leasing_stage1.json + leasing_stage2.json
- tests/test_engine.py — 25/25 PASSED

### Что не затронуто
- frontend/ — не изменялся
- HTTP-слой — следующий PR